### PR TITLE
make sure tabs are always tabs. 

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -30,7 +30,7 @@ if mkdir "${LOCKDIR}" &>/dev/null; then
           exit 3' 1 2 3 15
 
     # Send host check result
-    echo "${HOSTNAME}	0	Checked by $0" | ${NSCA} -H ${NSCASERVER} -c ${NSCACONF} > /dev/null
+    echo -e "${HOSTNAME}\t0\tChecked by $0" | ${NSCA} -H ${NSCASERVER} -c ${NSCACONF} > /dev/null
     if [ ${MQTTHOST} ]; then
         mosquitto_pub -h ${MQTTHOST} -t ${MQTTTOPIC} -m "{'host':'${HOSTNAME}', 'check':'${HOSTNAME}', 'returncode':'0', 'data':'Checked by $0'}"
     fi
@@ -44,7 +44,7 @@ if mkdir "${LOCKDIR}" &>/dev/null; then
       DATA=`${CHECKPATH}/${CHECKCMD}`
       RETVAL=$?
 
-      echo "${HOSTNAME}	${CHECKNAME}	${RETVAL}	${DATA}" | ${NSCA} -H ${NSCASERVER} -c ${NSCACONF}
+      echo -e "${HOSTNAME}\t${CHECKNAME}\t${RETVAL}\t${DATA}" | ${NSCA} -H ${NSCASERVER} -c ${NSCACONF}
 
       if [ ${MQTTHOST} ]; then
         mosquitto_pub -h ${MQTTHOST} -t ${MQTTTOPIC} -m "{'host':'${HOSTNAME}', 'check':'${CHECKNAME}', 'returncode':'${RETVAL}', 'data':'${DATA}'}"


### PR DESCRIPTION
Copy-paste might not make tabs tabs. Some text editors or lint tools replace tabs with 4 spaces.
